### PR TITLE
Add migrations for applications and application_pets tables

### DIFF
--- a/db/migrate/20240208234154_create_applications.rb
+++ b/db/migrate/20240208234154_create_applications.rb
@@ -1,0 +1,11 @@
+class CreateApplications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :applications do |t|
+      t.string :name
+      t.string :address
+      t.string :endorsement
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240208234553_create_application_pets.rb
+++ b/db/migrate/20240208234553_create_application_pets.rb
@@ -1,0 +1,10 @@
+class CreateApplicationPets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :application_pets do |t|
+      t.references :application, null: false, foreign_key: true
+      t.references :pet, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_02_24_213052) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_234553) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "application_pets", force: :cascade do |t|
+    t.bigint "application_id", null: false
+    t.bigint "pet_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_id"], name: "index_application_pets_on_application_id"
+    t.index ["pet_id"], name: "index_application_pets_on_pet_id"
+  end
+
+  create_table "applications", force: :cascade do |t|
+    t.string "name"
+    t.string "address"
+    t.string "endorsement"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "pets", force: :cascade do |t|
     t.boolean "adoptable"
@@ -52,6 +69,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_02_24_213052) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "application_pets", "applications"
+  add_foreign_key "application_pets", "pets"
   add_foreign_key "pets", "shelters"
   add_foreign_key "veterinarians", "veterinary_offices"
 end


### PR DESCRIPTION
Adds two additional tables to the database schema to create our many to many association
- Applications table with name, address, and endorsement columns
- Application Pets table with pet id and application id columns